### PR TITLE
chore: Use double quotes in version.ts file

### DIFF
--- a/bump_version.ts
+++ b/bump_version.ts
@@ -25,7 +25,7 @@ async function bumpVersion(type: "patch" | "minor" | "major") {
     await Deno.writeTextFile(
       "version.ts",
       `
-const version = '${json.version}';
+const version = "${json.version}";
 export default version;
       `.trim() + "\n",
     );

--- a/version.ts
+++ b/version.ts
@@ -1,2 +1,2 @@
-const version = '0.1.26';
+const version = "0.1.26";
 export default version;


### PR DESCRIPTION
Deno was formatting `version.ts` every time to use double quotes.